### PR TITLE
Add edit/delete for custom verses; make them non-shareable

### DIFF
--- a/src/app/favorites/page.tsx
+++ b/src/app/favorites/page.tsx
@@ -5,6 +5,10 @@ import { useState } from "react";
 import { ActionPill } from "@/components/ActionPill";
 import { AppShell } from "@/components/AppShell";
 import { BibleReferenceLink } from "@/components/BibleReferenceLink";
+import {
+  CustomPromiseCompose,
+  type ComposeEditing,
+} from "@/components/CustomPromiseCompose";
 import { SaveHeartButton } from "@/components/SaveHeartButton";
 import { ShareTruthCard } from "@/components/ShareTruthCard";
 import { Toast } from "@/components/Toast";
@@ -21,6 +25,7 @@ export default function FavoritesScreen() {
   const custom = useCustomLibrary();
   const share = useShareTruth();
   const [customToast, setCustomToast] = useState("");
+  const [editing, setEditing] = useState<ComposeEditing | null>(null);
 
   const resolveSavedTruth = (id: string): Truth | undefined => {
     if (id.startsWith("lie-")) {
@@ -42,22 +47,27 @@ export default function FavoritesScreen() {
     setTimeout(() => setCustomToast(""), 1800);
   };
 
-  const shareCustom = async (truth: Truth) => {
-    const text = `"${truth.statement}" - ${truth.reference}`;
-    if (typeof navigator !== "undefined" && navigator.share) {
-      try {
-        await navigator.share({ title: "What God Says About Me", text });
-        return;
-      } catch {
-        // fall through
-      }
+  const openEdit = (id: string) => {
+    if (id.startsWith("lie-custom-struggle-")) {
+      const struggle = custom.struggles.find((s) => `lie-${s.id}` === id);
+      if (struggle) setEditing({ kind: "struggle", value: struggle });
+      return;
     }
-    try {
-      await navigator.clipboard.writeText(text);
-      flashCustomToast("Link copied");
-    } catch {
-      flashCustomToast("Could not copy link");
+    const truth = custom.truths.find((t) => t.id === id);
+    if (truth) setEditing({ kind: "truth", value: truth });
+  };
+
+  const deleteCustom = (entry: ComposeEditing) => {
+    const cardId =
+      entry.kind === "struggle" ? `lie-${entry.value.id}` : entry.value.id;
+    if (entry.kind === "struggle") {
+      custom.removeStruggle(entry.value.id);
+    } else {
+      custom.removeTruth(entry.value.id);
     }
+    if (favorites.isSaved(cardId)) favorites.toggleSaved(cardId);
+    setEditing(null);
+    flashCustomToast("Deleted");
   };
 
   const savedTruths = favorites.savedIds
@@ -99,17 +109,19 @@ export default function FavoritesScreen() {
                     saved
                     onClick={() => favorites.toggleSaved(truth.id)}
                   />
-                  <ActionPill
-                    label="Share"
-                    variant="tint"
-                    onClick={() => {
-                      if (isCustom(truth.id)) {
-                        void shareCustom(truth);
-                        return;
-                      }
-                      share.openShareTruth(truth.id);
-                    }}
-                  />
+                  {isCustom(truth.id) ? (
+                    <ActionPill
+                      label="Edit"
+                      variant="tint"
+                      onClick={() => openEdit(truth.id)}
+                    />
+                  ) : (
+                    <ActionPill
+                      label="Share"
+                      variant="tint"
+                      onClick={() => share.openShareTruth(truth.id)}
+                    />
+                  )}
                 </div>
               </div>
             ))
@@ -138,6 +150,24 @@ export default function FavoritesScreen() {
         }}
       />
       <Toast message={share.toast || customToast} />
+
+      <CustomPromiseCompose
+        key={editing ? editing.value.id : "new"}
+        visible={editing !== null}
+        editing={editing ?? undefined}
+        onCancel={() => setEditing(null)}
+        onSaveTruth={() => setEditing(null)}
+        onSaveStruggle={() => setEditing(null)}
+        onUpdateTruth={(id, truth) => {
+          custom.updateTruth(id, truth);
+          setEditing(null);
+        }}
+        onUpdateStruggle={(id, struggle) => {
+          custom.updateStruggle(id, struggle);
+          setEditing(null);
+        }}
+        onDelete={deleteCustom}
+      />
     </>
   );
 }

--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -5,7 +5,10 @@ import { useMemo, useState } from "react";
 import { ActionPill } from "@/components/ActionPill";
 import { AppShell } from "@/components/AppShell";
 import { BibleReferenceLink } from "@/components/BibleReferenceLink";
-import { CustomPromiseCompose } from "@/components/CustomPromiseCompose";
+import {
+  CustomPromiseCompose,
+  type ComposeEditing,
+} from "@/components/CustomPromiseCompose";
 import { SaveHeartButton } from "@/components/SaveHeartButton";
 import { ShareTruthCard } from "@/components/ShareTruthCard";
 import { Toast } from "@/components/Toast";
@@ -13,7 +16,6 @@ import { TruthLibraryFilters } from "@/components/TruthLibraryFilters";
 import { useContent, useStruggles, useVerses } from "@/data/ContentProvider";
 import { getShareableTruthById, truthFromStruggle } from "@/data/content";
 import { filterLibraryCards, type LibraryFilter } from "@/data/libraryFilters";
-import type { Truth } from "@/data/verseUtils";
 import { useCustomLibrary } from "@/hooks/useCustomLibrary";
 import { useFavorites } from "@/hooks/useFavorites";
 import { useShareTruth } from "@/hooks/useShareTruth";
@@ -33,6 +35,7 @@ export default function LibraryScreen() {
   });
   const [filterOpen, setFilterOpen] = useState(false);
   const [composeOpen, setComposeOpen] = useState(false);
+  const [editing, setEditing] = useState<ComposeEditing | null>(null);
 
   const truthCards = useMemo(
     () => [...custom.truths, ...truths],
@@ -62,22 +65,32 @@ export default function LibraryScreen() {
     setTimeout(() => setCustomToast(""), 1800);
   };
 
-  const shareCustom = async (truth: Truth) => {
-    const text = `"${truth.statement}" - ${truth.reference}`;
-    if (typeof navigator !== "undefined" && navigator.share) {
-      try {
-        await navigator.share({ title: "What God Says About Me", text });
-        return;
-      } catch {
-        // fall through
-      }
+  const openEdit = (id: string) => {
+    if (id.startsWith("lie-custom-struggle-")) {
+      const struggle = custom.struggles.find((s) => `lie-${s.id}` === id);
+      if (struggle) setEditing({ kind: "struggle", value: struggle });
+      return;
     }
-    try {
-      await navigator.clipboard.writeText(text);
-      flashCustomToast("Link copied");
-    } catch {
-      flashCustomToast("Could not copy link");
+    const truth = custom.truths.find((t) => t.id === id);
+    if (truth) setEditing({ kind: "truth", value: truth });
+  };
+
+  const closeEditor = () => {
+    setComposeOpen(false);
+    setEditing(null);
+  };
+
+  const deleteCustom = (entry: ComposeEditing) => {
+    const cardId =
+      entry.kind === "struggle" ? `lie-${entry.value.id}` : entry.value.id;
+    if (entry.kind === "struggle") {
+      custom.removeStruggle(entry.value.id);
+    } else {
+      custom.removeTruth(entry.value.id);
     }
+    if (favorites.isSaved(cardId)) favorites.toggleSaved(cardId);
+    closeEditor();
+    flashCustomToast("Deleted");
   };
 
   return (
@@ -137,16 +150,17 @@ export default function LibraryScreen() {
                     saved={favorites.isSaved(truth.id)}
                     onClick={() => favorites.toggleSaved(truth.id)}
                   />
-                  <ActionPill
-                    label="Share"
-                    onClick={() => {
-                      if (isCustom(truth.id)) {
-                        void shareCustom(truth);
-                        return;
-                      }
-                      share.openShareTruth(truth.id);
-                    }}
-                  />
+                  {isCustom(truth.id) ? (
+                    <ActionPill
+                      label="Edit"
+                      onClick={() => openEdit(truth.id)}
+                    />
+                  ) : (
+                    <ActionPill
+                      label="Share"
+                      onClick={() => share.openShareTruth(truth.id)}
+                    />
+                  )}
                 </div>
               </div>
             ))
@@ -186,18 +200,29 @@ export default function LibraryScreen() {
       <Toast message={share.toast || customToast} />
 
       <CustomPromiseCompose
-        visible={composeOpen}
-        onCancel={() => setComposeOpen(false)}
+        key={editing ? editing.value.id : "new"}
+        visible={composeOpen || editing !== null}
+        editing={editing ?? undefined}
+        onCancel={closeEditor}
         onSaveTruth={(truth) => {
           custom.addTruth(truth);
-          setComposeOpen(false);
+          closeEditor();
           setFilter({ group: null, category: truth.category });
         }}
         onSaveStruggle={(struggle) => {
           custom.addStruggle(struggle);
-          setComposeOpen(false);
+          closeEditor();
           setFilter({ group: null, category: struggle.category });
         }}
+        onUpdateTruth={(id, truth) => {
+          custom.updateTruth(id, truth);
+          closeEditor();
+        }}
+        onUpdateStruggle={(id, struggle) => {
+          custom.updateStruggle(id, struggle);
+          closeEditor();
+        }}
+        onDelete={deleteCustom}
       />
     </>
   );

--- a/src/components/CustomPromiseCompose.tsx
+++ b/src/components/CustomPromiseCompose.tsx
@@ -8,6 +8,10 @@ type ComposeType = "truth" | "struggle";
 type AddTruthInput = Omit<Truth, "id">;
 type AddStruggleInput = Omit<Struggle, "id">;
 
+export type ComposeEditing =
+  | { kind: "truth"; value: Truth }
+  | { kind: "struggle"; value: Struggle };
+
 const truthCategories: TruthCategory[] = [
   "Purpose",
   "Identity",
@@ -48,20 +52,40 @@ const defaultStruggle: AddStruggleInput = {
   prayer: "",
 };
 
+function stripId<T extends { id: string }>(value: T): Omit<T, "id"> {
+  const { id, ...rest } = value;
+  void id;
+  return rest;
+}
+
 export function CustomPromiseCompose({
   visible,
   onCancel,
   onSaveTruth,
   onSaveStruggle,
+  editing,
+  onUpdateTruth,
+  onUpdateStruggle,
+  onDelete,
 }: {
   visible: boolean;
   onCancel: () => void;
   onSaveTruth: (truth: AddTruthInput) => void;
   onSaveStruggle: (struggle: AddStruggleInput) => void;
+  editing?: ComposeEditing;
+  onUpdateTruth?: (id: string, truth: AddTruthInput) => void;
+  onUpdateStruggle?: (id: string, struggle: AddStruggleInput) => void;
+  onDelete?: (editing: ComposeEditing) => void;
 }) {
-  const [type, setType] = useState<ComposeType>("truth");
-  const [truth, setTruth] = useState<AddTruthInput>(defaultTruth);
-  const [struggle, setStruggle] = useState<AddStruggleInput>(defaultStruggle);
+  const isEditing = Boolean(editing);
+  const [type, setType] = useState<ComposeType>(editing?.kind ?? "truth");
+  const [truth, setTruth] = useState<AddTruthInput>(
+    editing?.kind === "truth" ? stripId(editing.value) : defaultTruth,
+  );
+  const [struggle, setStruggle] = useState<AddStruggleInput>(
+    editing?.kind === "struggle" ? stripId(editing.value) : defaultStruggle,
+  );
+  const [confirmDelete, setConfirmDelete] = useState(false);
 
   if (!visible) return null;
 
@@ -93,16 +117,21 @@ export function CustomPromiseCompose({
   const save = () => {
     if (!canSave) return;
     if (type === "truth") {
-      onSaveTruth({
+      const payload: AddTruthInput = {
         ...truth,
         statement: truth.statement.trim(),
         reference: truth.reference.trim(),
         verse: truth.verse.trim(),
         reflectionQuestion: truth.reflectionQuestion.trim(),
         journalPrompt: truth.journalPrompt.trim(),
-      });
+      };
+      if (editing?.kind === "truth") {
+        onUpdateTruth?.(editing.value.id, payload);
+      } else {
+        onSaveTruth(payload);
+      }
     } else {
-      onSaveStruggle({
+      const payload: AddStruggleInput = {
         ...struggle,
         label: struggle.label.trim(),
         lie: struggle.lie.trim(),
@@ -115,7 +144,12 @@ export function CustomPromiseCompose({
         ],
         reflection: struggle.reflection.trim(),
         prayer: struggle.prayer.trim(),
-      });
+      };
+      if (editing?.kind === "struggle") {
+        onUpdateStruggle?.(editing.value.id, payload);
+      } else {
+        onSaveStruggle(payload);
+      }
     }
     reset();
   };
@@ -125,32 +159,46 @@ export function CustomPromiseCompose({
     onCancel();
   };
 
+  const remove = () => {
+    if (!editing) return;
+    if (!confirmDelete) {
+      setConfirmDelete(true);
+      return;
+    }
+    onDelete?.(editing);
+    reset();
+  };
+
   return (
     <div className="fixed inset-0 z-50 flex justify-center bg-page">
       <div className="w-full max-w-[480px] overflow-y-auto px-6 pb-11 pt-[max(env(safe-area-inset-top),48px)]">
         <p className="text-[11px] font-bold uppercase tracking-[1.6px] text-accent">
-          Add your own promise
+          {isEditing ? "Edit your promise" : "Add your own promise"}
         </p>
         <h1 className="mt-2.5 font-serif text-[30px] leading-[38px] text-scriptureInk">
-          Create a custom truth or struggle
+          {isEditing
+            ? `Edit this custom ${type}`
+            : "Create a custom truth or struggle"}
         </h1>
         <p className="mt-2.5 text-sm leading-[21px] text-softInk">
           Include Scripture, a clear statement, and a reflection prompt so this
           entry is complete and useful later.
         </p>
 
-        <div className="mt-[18px] flex gap-2.5">
-          <TypeButton
-            label="Truth"
-            active={type === "truth"}
-            onClick={() => setType("truth")}
-          />
-          <TypeButton
-            label="Struggle"
-            active={type === "struggle"}
-            onClick={() => setType("struggle")}
-          />
-        </div>
+        {!isEditing && (
+          <div className="mt-[18px] flex gap-2.5">
+            <TypeButton
+              label="Truth"
+              active={type === "truth"}
+              onClick={() => setType("truth")}
+            />
+            <TypeButton
+              label="Struggle"
+              active={type === "struggle"}
+              onClick={() => setType("struggle")}
+            />
+          </div>
+        )}
 
         {type === "truth" ? (
           <div className="mt-[18px] flex flex-col gap-2">
@@ -290,7 +338,20 @@ export function CustomPromiseCompose({
           </div>
         )}
 
-        <div className="mt-[22px] flex justify-end gap-3">
+        <div className="mt-[22px] flex flex-wrap items-center justify-end gap-3">
+          {isEditing && (
+            <button
+              type="button"
+              onClick={remove}
+              className={`mr-auto flex min-h-[48px] items-center rounded-full px-[18px] text-[15px] font-bold focus-ring ${
+                confirmDelete
+                  ? "bg-danger text-page"
+                  : "border border-danger text-danger"
+              }`}
+            >
+              {confirmDelete ? "Tap again to delete" : "Delete"}
+            </button>
+          )}
           <button
             type="button"
             onClick={cancel}
@@ -306,7 +367,7 @@ export function CustomPromiseCompose({
               canSave ? "bg-ink text-page" : "bg-tint text-mutedInk"
             }`}
           >
-            Add
+            {isEditing ? "Save" : "Add"}
           </button>
         </div>
       </div>

--- a/src/hooks/useCustomLibrary.ts
+++ b/src/hooks/useCustomLibrary.ts
@@ -34,6 +34,30 @@ export function useCustomLibrary() {
     return nextTruth;
   }, []);
 
+  const updateTruth = useCallback((id: string, truth: AddTruthInput) => {
+    setContent((current) => {
+      const next = {
+        ...current,
+        truths: current.truths.map((item) =>
+          item.id === id ? { ...truth, id } : item,
+        ),
+      };
+      saveCustomLibraryContent(next);
+      return next;
+    });
+  }, []);
+
+  const removeTruth = useCallback((id: string) => {
+    setContent((current) => {
+      const next = {
+        ...current,
+        truths: current.truths.filter((item) => item.id !== id),
+      };
+      saveCustomLibraryContent(next);
+      return next;
+    });
+  }, []);
+
   const addStruggle = useCallback((struggle: AddStruggleInput) => {
     const nextStruggle: Struggle = {
       ...struggle,
@@ -50,11 +74,42 @@ export function useCustomLibrary() {
     return nextStruggle;
   }, []);
 
+  const updateStruggle = useCallback(
+    (id: string, struggle: AddStruggleInput) => {
+      setContent((current) => {
+        const next = {
+          ...current,
+          struggles: current.struggles.map((item) =>
+            item.id === id ? { ...struggle, id } : item,
+          ),
+        };
+        saveCustomLibraryContent(next);
+        return next;
+      });
+    },
+    [],
+  );
+
+  const removeStruggle = useCallback((id: string) => {
+    setContent((current) => {
+      const next = {
+        ...current,
+        struggles: current.struggles.filter((item) => item.id !== id),
+      };
+      saveCustomLibraryContent(next);
+      return next;
+    });
+  }, []);
+
   return {
     ready,
     truths: content.truths,
     struggles: content.struggles,
     addTruth,
+    updateTruth,
+    removeTruth,
     addStruggle,
+    updateStruggle,
+    removeStruggle,
   };
 }


### PR DESCRIPTION
Custom truths and struggles could be created but never edited or
deleted. They also offered a Share button that only copied plain text
(custom entries have no public share URL).

- Replace the Share button with an Edit button on custom cards in both
  the Library and Favorites views; built-in cards keep Share.
- Reuse CustomPromiseCompose as an edit view: it prefills from the
  entry, hides the type toggle, saves via update, and includes a
  two-tap Delete button.
- Add updateTruth/removeTruth/updateStruggle/removeStruggle to
  useCustomLibrary. Deleting also clears the entry from favorites.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XiwrRbcu44TLoPta5KXfuw